### PR TITLE
Portable parsing of Selectors

### DIFF
--- a/MonticelloTonel-Core.package/TonelParser.class/instance/extractSelector..st
+++ b/MonticelloTonel-Core.package/TonelParser.class/instance/extractSelector..st
@@ -1,3 +1,28 @@
 private
 extractSelector: aString
-	^ RBParser parseMethodPattern: aString
+	| separators selectorStream keywords |
+	
+	separators := { 
+		Character space. 
+		Character tab. 
+		Character lf. 
+		Character newPage. 
+		Character cr. 
+		$:}.
+
+	keywords := Array new writeStream.
+	selectorStream := (self removeComments: aString) readStream.
+
+	[ selectorStream atEnd ]
+	whileFalse: [ | word ch |
+		word := String new writeStream.
+		[ selectorStream atEnd not and: [ (separators includes: (ch := selectorStream next)) not ] ]
+		whileTrue: [ word nextPut: ch ].
+		ch = $: ifTrue: [ word nextPut: ch ]. 
+		word contents trimBoth ifNotEmpty: [ :v | keywords nextPut: v ] ].
+	keywords := keywords contents.
+
+	^ (keywords size <= 2 
+		ifTrue: [ keywords first]
+		ifFalse: [ ('' join: (keywords pairsCollect: [ :keyword :argument | keyword ])) ])
+		asSymbol

--- a/MonticelloTonel-Core.package/TonelParser.class/instance/removeComments..st
+++ b/MonticelloTonel-Core.package/TonelParser.class/instance/removeComments..st
@@ -1,0 +1,21 @@
+private
+removeComments: original
+	| newStream readStream inComment |
+	
+	newStream := original copy writeStream.
+	readStream := original readStream.
+	inComment := false.
+	
+	[ readStream atEnd ] whileFalse: [ | ch |
+		
+		ch := readStream next.
+		
+		(ch = $") ifTrue:[
+			inComment := inComment not.
+			ch := readStream next.
+		].
+		
+		(inComment or:[ ch isNil]) ifFalse: [ newStream nextPut: ch	 ]
+	].
+	
+	^ newStream contents

--- a/MonticelloTonel-Tests.package/TonelParserTest.class/instance/testExtractSelectorWithComments.st
+++ b/MonticelloTonel-Tests.package/TonelParserTest.class/instance/testExtractSelectorWithComments.st
@@ -1,0 +1,20 @@
+tests
+testExtractSelectorWithComments
+	| parser |
+	
+	parser := TonelParser new.
+	
+	self assert: (parser extractSelector: 'unary "comment"') equals: #unary.
+	self assert: (parser extractSelector: '+ "comment" something') equals: #+.
+	self assert: (parser extractSelector: '==> "comment" other') equals: #==>.
+	self 
+		assert: (parser extractSelector: 'some: arg1 "comment"  keyword: arg2  "comment" selector: arg3 "comment"') 
+		equals: #some:keyword:selector:.
+	self 
+		assert: (parser extractSelector: 'some: 	arg1 "comment" keyword:arg2 selector: arg3') 
+		equals: #some:keyword:selector:.
+	self 
+		assert: (parser extractSelector: 'some: arg1 "comment"
+keyword: arg2 "comment"
+selector: arg3') 
+		equals: #some:keyword:selector:.


### PR DESCRIPTION
-  Adding a portable version of extractSelector that can handle comments in the selector.
- Adding a test for it.

Cumplí como Randazzo (?)