### PR TITLE
add missing files

### DIFF
--- a/MigrateFromFileTree.md
+++ b/MigrateFromFileTree.md
@@ -33,11 +33,13 @@ repo savedPackages do: [ :each | | filetreePackage |
 		subDirWithDelim, (IceLibgitFiletreeWriter directoryNameFor: each). } ].
 
 repo addProperties: (IceRepositoryProperties fromDictionary: { #format -> #tonel } asDictionary).
+"add .properties"
+repo addFilesToIndex: { (subDirWithDelim, '.properties').}.
 
 "remove .filetreee remaining"
 filetreeFiles := sourceDir allChildrenMatching: '.filetree'.
 filetreeFiles do: #ensureDelete.
-repo addFilesToIndex: (filetreeFiles collect: [ :each | (each relativeTo: locationDir) fullName ]).
+repo addFilesToIndex: (filetreeFiles collect: [ :each | ((each relativeTo: locationDir) printWithDelimiter: $/) ]).
 
 repo 
 	commitIndexWithMessage: 'sources migrated' 


### PR DESCRIPTION
some files were left out of the commit.
for example:
.properties was not added
.filetree at the root of the source dir was not added.
there is something wrong with way the relative path is added to the index of the repository.
i tested once and it works in pharo 6.1. 
is it ok?