### PR TITLE
Break infinite loop when selector was not found.

### DIFF
--- a/MonticelloTonel-Core.package/TonelWriteError.class/README.md
+++ b/MonticelloTonel-Core.package/TonelWriteError.class/README.md
@@ -1,0 +1,2 @@
+I'm a writing error.
+I happen whenever an unrecoverable problem was encountered during writing of tonel.

--- a/MonticelloTonel-Core.package/TonelWriteError.class/properties.json
+++ b/MonticelloTonel-Core.package/TonelWriteError.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "PeterUhnak 10/7/2018 16:50",
+	"super" : "Error",
+	"category" : "MonticelloTonel-Core",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "TonelWriteError",
+	"type" : "normal"
+}

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/splitMethodSource.into..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/splitMethodSource.into..st
@@ -13,6 +13,8 @@ splitMethodSource: aMethodDefinition into: aBlock
 	[ (self selectorIsComplete: keywords in: declaration originalContents) not 
 		or: [ ':+-/\*~<>=@,%|&?!' includes: declaration contents trimRight last ] ]
 	whileTrue: [ 
+		"stop infinite loop if no match was found"
+		source atEnd ifTrue: [ TonelWriteError signal: 'Cannot find selector in source for ', aMethodDefinition asString ].
 		"get separators"
 		[ source atEnd not and: [ source peek isSeparator ] ]
 			whileTrue: [ declaration nextPut: source next ].

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSplitMethodSourceIntoCorrupted.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSplitMethodSourceIntoCorrupted.st
@@ -1,0 +1,17 @@
+tests
+testSplitMethodSourceIntoCorrupted
+	| writer definition |
+	writer := TonelWriter new.
+
+	"Sometimes data loaded from old MCZs are corrupted and the selector doesn't match the source, resulting in infinite search loop."
+	definition := MCMethodDefinition
+		className: #SomeClass
+		selector: #nameØY
+		category: 'accessing'
+		timeStamp: nil
+		source:
+			'named: aString
+	^ self named: aString environment: self defaultEnvironment'.
+	self
+		should: [ writer splitMethodSource: definition into: [ :d :s |  ] ]
+		raise: TonelWriteError


### PR DESCRIPTION
It is not uncommon for MCZ files to be corrupted, which can result in infinite loop during Tonel writeout.

See the test for example (taken from `Glamour-Examples-tg.36.mcz`, but I see it frequently).