### PR TITLE
55-add-api-to-export-one-class-in-stream

### DIFF
--- a/MonticelloTonel-Core.package/TonelWriter.class/README.md
+++ b/MonticelloTonel-Core.package/TonelWriter.class/README.md
@@ -13,6 +13,14 @@ My main methods are
 - ==#writeVersion:== that receives as argument a monticello version to write, from where I'll extract the corresponding monticello snapshot.
 - ==#writeSnapshot:== that receives as argument a monticello snapshot to write, from where I'll write all the contained definitions.
 
+I also provide a way to easily export a single class in the Tonel format to a stream. 
+
+[[[
+	TonelWriter sourceCodeOf: self.
+	
+	(FileSystem memory / 'test.st') writeStreamDo: [ :s | TonelWriter exportClass: self on: s ]; yourself.
+]]]
+
 ! Implementation details
 
 Notice that while writing, if the written package/snapshot already exists in the directory I'll overwrite it (i.e., remove it and recreate it).

--- a/MonticelloTonel-Core.package/TonelWriter.class/class/exportClass.on..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/class/exportClass.on..st
@@ -1,0 +1,5 @@
+writing - class
+exportClass: aClass on: aStream
+	"I take a class and a stream as parameter and export the class in Tonel format into the stream."
+	
+	^ self new exportClass: aClass on: aStream

--- a/MonticelloTonel-Core.package/TonelWriter.class/class/sourceCodeOf..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/class/sourceCodeOf..st
@@ -1,0 +1,5 @@
+writing - class
+sourceCodeOf: aClass
+	"I take as a parameter a class and I return it's tonel export as a String."
+	
+	^ String streamContents: [ :aStream | self new exportClass: aClass on: aStream ]

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/exportClass.on..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/exportClass.on..st
@@ -1,0 +1,5 @@
+writing
+exportClass: aClass on: aStream
+	snapshot := (MCVersion package: (MCPackage named: aClass package name)) snapshot.
+	self writeClass: aClass asClassDefinition on: aStream.
+	^ aStream

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/snapshot..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/snapshot..st
@@ -1,0 +1,3 @@
+accessing
+snapshot: anObject
+	snapshot := anObject

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/writeClass..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/writeClass..st
@@ -1,12 +1,5 @@
 writing
 writeClass: aClassDefinition
-	[ 
-		self fileUtils 
-			writeStreamFor: (self fileNameFor: aClassDefinition) 
-			in: self packageDir 
-			do: [ :aStream | 
-				self writeClassDefinition: aClassDefinition on: aStream.
-				self writeClassSideMethodDefinitions: aClassDefinition on: aStream.
-				self writeInstanceSideMethodDefinitions: aClassDefinition on: aStream ] ]
-	on: TonelShouldIgnore
-	do: [ :e | self logCr: 'ignoring: ', aClassDefinition asString ]
+	[ self fileUtils writeStreamFor: (self fileNameFor: aClassDefinition) in: self packageDir do: [ :aStream | self writeClass: aClassDefinition on: aStream ] ]
+		on: TonelShouldIgnore
+		do: [ :e | self logCr: 'ignoring: ' , aClassDefinition asString ]

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/writeClass.on..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/writeClass.on..st
@@ -1,0 +1,7 @@
+writing
+writeClass: aClassDefinition on: aStream
+	[ self writeClassDefinition: aClassDefinition on: aStream.
+	self writeClassSideMethodDefinitions: aClassDefinition on: aStream.
+	self writeInstanceSideMethodDefinitions: aClassDefinition on: aStream ]
+		on: TonelShouldIgnore
+		do: [ :e | self logCr: 'ignoring: ' , aClassDefinition asString ]

--- a/MonticelloTonel-Core.package/TonelWriter.class/properties.json
+++ b/MonticelloTonel-Core.package/TonelWriter.class/properties.json
@@ -1,5 +1,5 @@
 {
-	"commentStamp" : "GuillermoPolito 7/11/2018 11:07",
+	"commentStamp" : "CyrilFerlicot 10/23/2018 15:52",
 	"super" : "MCWriter",
 	"category" : "MonticelloTonel-Core",
 	"classinstvars" : [ ],

--- a/MonticelloTonel-Tests.package/TonelMock.class/README.md
+++ b/MonticelloTonel-Tests.package/TonelMock.class/README.md
@@ -1,0 +1,4 @@
+Description
+--------------------
+
+I am a simple Mock for Tonel export test

--- a/MonticelloTonel-Tests.package/TonelMock.class/class/classMethod.st
+++ b/MonticelloTonel-Tests.package/TonelMock.class/class/classMethod.st
@@ -1,0 +1,3 @@
+accessing
+classMethod
+	^ 8

--- a/MonticelloTonel-Tests.package/TonelMock.class/instance/instanceMethod.st
+++ b/MonticelloTonel-Tests.package/TonelMock.class/instance/instanceMethod.st
@@ -1,0 +1,3 @@
+accessing
+instanceMethod
+	^ true

--- a/MonticelloTonel-Tests.package/TonelMock.class/properties.json
+++ b/MonticelloTonel-Tests.package/TonelMock.class/properties.json
@@ -1,0 +1,11 @@
+{
+	"commentStamp" : "CyrilFerlicot 10/23/2018 15:55",
+	"super" : "Object",
+	"category" : "MonticelloTonel-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [ ],
+	"name" : "TonelMock",
+	"type" : "normal"
+}

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/actualClass.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/actualClass.st
@@ -1,0 +1,3 @@
+accessing
+actualClass
+	^ TonelWriter

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSourceCodeOf.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSourceCodeOf.st
@@ -3,7 +3,7 @@ testSourceCodeOf
 	self
 		assert: (self actualClass sourceCodeOf: TonelMock)
 		equals:
-			'"
+			('"
 Description
 --------------------
 
@@ -25,3 +25,4 @@ TonelMock >> instanceMethod [
 	^ true
 ]
 '
+				withLineEndings: OSPlatform current lineEnding)

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSourceCodeOf.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSourceCodeOf.st
@@ -1,0 +1,27 @@
+tests
+testSourceCodeOf
+	self
+		assert: (self actualClass sourceCodeOf: TonelMock)
+		equals:
+			'"
+Description
+--------------------
+
+I am a simple Mock for Tonel export test
+"
+Class {
+	#name : #TonelMock,
+	#superclass : #Object,
+	#category : #''MonticelloTonel-Tests''
+}
+
+{ #category : #accessing }
+TonelMock class >> classMethod [
+	^ 8
+]
+
+{ #category : #accessing }
+TonelMock >> instanceMethod [
+	^ true
+]
+'

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSplitMethodSourceInto.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testSplitMethodSourceInto.st
@@ -5,7 +5,7 @@ testSplitMethodSourceInto
 	newLine := OSPlatform current lineEnding.
 	tab := Character tab asString.
 	space := Character space asString.
-	writer := TonelWriter new.
+	writer := self actualClass new.
 
 	"simplest split"
 	definition := MCMethodDefinition

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteClassDefinitionOn.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteClassDefinitionOn.st
@@ -2,7 +2,7 @@ tests
 testWriteClassDefinitionOn
 	| writer def stream |
 	
-	writer := TonelWriter new.
+	writer := self actualClass new.
 
 	stream := String new writeStream.
 	def := MCClassDefinition

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteMethodDefinitionOn.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteMethodDefinitionOn.st
@@ -2,7 +2,7 @@ tests
 testWriteMethodDefinitionOn
 	| writer def stream |
 	
-	writer := TonelWriter new.
+	writer := self actualClass new.
 
 	stream := String new writeStream.
 	def := MCMethodDefinition 

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshot.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshot.st
@@ -3,7 +3,7 @@ testWriteSnapshot
 	| writer mem nl |
 	
 	mem := FileSystem memory root.
-	writer := TonelWriter on: mem.
+	writer := self actualClass on: mem.
 	writer writeSnapshot: self mockSnapshot.
 	
 	self assert: (mem / 'MonticelloMocks') exists.


### PR DESCRIPTION
Add a way to get the source code of a class directly without having to export all the package in a file system from a MCVersion.

This might fix issue 55 if this is what Ben wants.I would love a review since I don't know how MCPackage/Version/Snapshot works. I did something functionnal but maybe there is something more performant to do.