### PR TITLE
make sure the category is a symbol

### DIFF
--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/typeClassDefinitionOf..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/typeClassDefinitionOf..st
@@ -29,6 +29,6 @@ typeClassDefinitionOf: aClassDefinition
 		ifNotEmpty: [ :vars | definition at: #classInstVars put: vars asArray ].
 
 	definition 		
-		at: #category put: aClassDefinition category.
+		at: #category put: aClassDefinition category asSymbol.
 	
 	^ self toSTON: definition


### PR DESCRIPTION
This is to make sure Tonel writes the category always as a symbol. 

It started from the pull request of VMMaker code into opensmalltalk vm where we have commits like: https://github.com/OpenSmalltalk/opensmalltalk-vm/commit/4accb9e06df33a2326c0b2934cf15ac89edf3c06.