### PR TITLE
67-Tonel-should-ignore-hidden-files-when-loading-a-project

### DIFF
--- a/MonticelloTonel-Core.package/TonelReader.class/instance/canBeLoaded..st
+++ b/MonticelloTonel-Core.package/TonelReader.class/instance/canBeLoaded..st
@@ -2,4 +2,8 @@ private
 canBeLoaded: aFileReference
 	| fileName |
 	fileName := self fileUtils fileName: aFileReference. 
+	
+	"If the file begins with a `.` then it is an hidden file and should not be loaded."
+	(fileName beginsWith: '.') ifTrue: [ ^ false ].
+
 	^ fileName ~= 'package.st' and: [ fileName endsWith: '.st' ]

--- a/MonticelloTonel-Tests.package/TonelReaderTest.class/instance/testHiddenFilesAreIgnored.st
+++ b/MonticelloTonel-Tests.package/TonelReaderTest.class/instance/testHiddenFilesAreIgnored.st
@@ -1,0 +1,17 @@
+tests
+testHiddenFilesAreIgnored
+	| snapshot mem reader |
+	
+	snapshot := self mockSnapshot.
+	mem := self newMemoryFileSystemSnapshot: snapshot.
+	(mem / 'MonticelloMocks' / '._MCMockClassG.class.st') ensureCreateFile; writeStreamDo: [ :s | s << 'This file should be ignored' ].
+	reader := TonelReader on: mem fileName: 'MonticelloMocks'.
+	reader loadDefinitions.
+	
+	self 
+		assert: reader definitions size 
+		equals: snapshot definitions size.
+		
+	reader definitions sorted 
+		with: snapshot definitions sorted
+		do: [ :a :b | self assertDefinition: a and: b ]


### PR DESCRIPTION
Ignore hidden files while reading. 

Fixes #67