### PR TITLE
64-TonelWriter-classexportClasson-is-slow-

### DIFF
--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/exportClass.on..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/exportClass.on..st
@@ -1,5 +1,8 @@
 writing
 exportClass: aClass on: aStream
-	snapshot := (MCVersion package: (MCPackage named: aClass package name)) snapshot.
+	snapshot := MCSnapshot
+		fromDefinitions:
+			{aClass asClassDefinition} , (aClass localMethods collect: [ :each | each asRingDefinition asMCMethodDefinition ])
+				, (aClass classSide localMethods collect: [ :each | each asRingDefinition asMCMethodDefinition ]).
 	self writeClass: aClass asClassDefinition on: aStream.
 	^ aStream


### PR DESCRIPTION
Speed up export of one class with Tonel + fix a bug on windows.

Fixes #64