### PR TITLE
76-Tonel-breaks-with-dots-after-selector

### DIFF
--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/splitMethodSource.into..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/splitMethodSource.into..st
@@ -18,8 +18,8 @@ splitMethodSource: aMethodDefinition into: aBlock
 		"get separators"
 		[ source atEnd not and: [ source peek isSeparator ] ]
 			whileTrue: [ declaration nextPut: source next ].
-		"take next word"
-		[ source atEnd not and: [ source peek isSeparator not ] ]
+		"take next word until we find a separator or a dot"
+		[ source atEnd not and: [ source peek ~= $. and: [ source peek isSeparator not ] ] ]
 			whileTrue: [ declaration nextPut: source next ] ].
 	aBlock 
 		value: (declaration contents trimLeft withLineEndings: self newLine)

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteBinaryInstanceMethodDefinitionWithDotNextToArgument.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteBinaryInstanceMethodDefinitionWithDotNextToArgument.st
@@ -1,0 +1,24 @@
+tests
+testWriteBinaryInstanceMethodDefinitionWithDotNextToArgument
+	| writer def stream |
+	
+	writer := self actualClass new.
+
+	stream := String new writeStream.
+	def := MCMethodDefinition 
+		className: #Object
+		classIsMeta: false
+		selector: #+
+		category: 'accessing' 
+		timeStamp: nil
+		source: '+ a.
+	^ 42'.
+	writer writeMethodDefinition: def on: stream. 
+	self 
+		assert: stream contents 
+		equals: ('
+{ #category : #accessing }
+Object >> + a [.
+	^ 42
+]
+' withLineEndings: OSPlatform current lineEnding).

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteKeywordInstanceMethodDefinitionWithDotNextToArgument.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteKeywordInstanceMethodDefinitionWithDotNextToArgument.st
@@ -1,0 +1,24 @@
+tests
+testWriteKeywordInstanceMethodDefinitionWithDotNextToArgument
+	| writer def stream |
+	
+	writer := self actualClass new.
+
+	stream := String new writeStream.
+	def := MCMethodDefinition 
+		className: #Object
+		classIsMeta: false
+		selector: #min:max
+		category: 'accessing' 
+		timeStamp: nil
+		source: 'min: a max: b.
+	^ 42'.
+	writer writeMethodDefinition: def on: stream. 
+	self 
+		assert: stream contents 
+		equals: ('
+{ #category : #accessing }
+Object >> min: a max: b [.
+	^ 42
+]
+' withLineEndings: OSPlatform current lineEnding).

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteUnaryInstanceMethodDefinitionWithDotNextToSelector.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteUnaryInstanceMethodDefinitionWithDotNextToSelector.st
@@ -1,0 +1,24 @@
+tests
+testWriteUnaryInstanceMethodDefinitionWithDotNextToSelector
+	| writer def stream |
+	
+	writer := self actualClass new.
+
+	stream := String new writeStream.
+	def := MCMethodDefinition 
+		className: #Object
+		classIsMeta: false
+		selector: #selector
+		category: 'accessing' 
+		timeStamp: nil
+		source: 'selector.
+	^ 42'.
+	writer writeMethodDefinition: def on: stream. 
+	self 
+		assert: stream contents 
+		equals: ('
+{ #category : #accessing }
+Object >> selector [.
+	^ 42
+]
+' withLineEndings: OSPlatform current lineEnding).


### PR DESCRIPTION
Fix #76
 - add tests for case of methods with dots
 - fix writer to stop reading when finding a dot