### PR TITLE
84-TonelWriterwriteSnapshot-includes-tag-name-in-package-name-when-theres-no-OrganizationDefinition

### DIFF
--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/createDefaultOrganizationFrom..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/createDefaultOrganizationFrom..st
@@ -5,7 +5,7 @@ createDefaultOrganizationFrom: aCollection
 	"simplest case, I answer the clas definition"
 	snapshot definitions 
 		detect: #isClassDefinition
-		ifFound: [ :each | ^ MCOrganizationDefinition categories: { each category } ].
+		ifFound: [ :each | ^ MCOrganizationDefinition categories: { each categoryWithoutTag } ].
 	
 	^ self createDefaultOrganizationFromDefinition: (snapshot definitions
 		detect: #isMethodDefinition

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/checkFilesStructureIn..st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/checkFilesStructureIn..st
@@ -16,7 +16,6 @@ checkFilesStructureIn: aFileReference
 			'MCMockClassG.class.st' 
 			'MCMockClassH.class.st' 
 			'MCMockClassI.class.st'
-			'MCMockClassJ.class.st'
 			'MCSnapshotTest.extension.st'
 			'package.st').
 	

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/checkFilesStructureIn..st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/checkFilesStructureIn..st
@@ -15,7 +15,8 @@ checkFilesStructureIn: aFileReference
 			'MCMockClassF.class.st' 
 			'MCMockClassG.class.st' 
 			'MCMockClassH.class.st' 
-			'MCMockClassI.class.st' 
+			'MCMockClassI.class.st'
+			'MCMockClassJ.class.st'
 			'MCSnapshotTest.extension.st'
 			'package.st').
 	

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithOrganizationAndOnlyOnceClassWithTag.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithOrganizationAndOnlyOnceClassWithTag.st
@@ -7,7 +7,7 @@ testWriteSnapshotWithOrganizationAndOnlyOnceClassWithTag
 	" Removing all elements from the snapshot except one class 
 	  which is classified in the Package's tag 'Tag' "
 	(aSnapshot definitions
-		select: [ :def | def className ~= #MCMockClassJ and: [ def isOrganizationDefinition not ]])
+		select: [ :def | def className ~= #MCMockClassI and: [ def isOrganizationDefinition not ]])
 		do: [ :each | aSnapshot definitions remove: each ].
 	memoryFileReference := FileSystem memory root.
 	writer := self actualClass on: memoryFileReference.

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithOrganizationAndOnlyOnceClassWithTag.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithOrganizationAndOnlyOnceClassWithTag.st
@@ -1,0 +1,17 @@
+tests
+testWriteSnapshotWithOrganizationAndOnlyOnceClassWithTag
+
+	| aSnapshot memoryFileReference writer |
+	" Taking a snapshot of the package MonticelloMocks "
+	aSnapshot := self mockSnapshot copy.
+	" Removing all elements from the snapshot except one class 
+	  which is classified in the Package's tag 'Tag' "
+	(aSnapshot definitions
+		select: [ :def | def className ~= #MCMockClassJ and: [ def isOrganizationDefinition not ]])
+		do: [ :each | aSnapshot definitions remove: each ].
+	memoryFileReference := FileSystem memory root.
+	writer := self actualClass on: memoryFileReference.
+	writer writeSnapshot: aSnapshot.
+	
+	self deny: (memoryFileReference / 'MonticelloMocks-Tag') exists.
+	self assert: (memoryFileReference / 'MonticelloMocks') exists.

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithoutOrganizationAndOnlyOnceClassWithTag.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithoutOrganizationAndOnlyOnceClassWithTag.st
@@ -1,0 +1,17 @@
+tests
+testWriteSnapshotWithoutOrganizationAndOnlyOnceClassWithTag
+
+	| aSnapshot memoryFileReference writer |
+	" Taking a snapshot of the package MonticelloMocks "
+	aSnapshot := self mockSnapshot copy.
+	" Removing all elements from the snapshot except one class 
+	  which is classified in the Package's tag 'Tag' "
+	(aSnapshot definitions
+		select: [ :def | def className ~= #MCMockClassJ ])
+		do: [ :each | aSnapshot definitions remove: each ].
+	memoryFileReference := FileSystem memory root.
+	writer := self actualClass on: memoryFileReference.
+	writer writeSnapshot: aSnapshot.
+	
+	self deny: (memoryFileReference / 'MonticelloMocks-Tag') exists.
+	self assert: (memoryFileReference / 'MonticelloMocks') exists.

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithoutOrganizationAndOnlyOnceClassWithTag.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteSnapshotWithoutOrganizationAndOnlyOnceClassWithTag.st
@@ -7,7 +7,7 @@ testWriteSnapshotWithoutOrganizationAndOnlyOnceClassWithTag
 	" Removing all elements from the snapshot except one class 
 	  which is classified in the Package's tag 'Tag' "
 	(aSnapshot definitions
-		select: [ :def | def className ~= #MCMockClassJ ])
+		select: [ :def | def className ~= #MCMockClassI ])
 		do: [ :each | aSnapshot definitions remove: each ].
 	memoryFileReference := FileSystem memory root.
 	writer := self actualClass on: memoryFileReference.


### PR DESCRIPTION
Tests for checking package name when there's no organization.
Using the class categoryWithoutTag for setting the name of its package