### PR TITLE
Failsafe tonel

### DIFF
--- a/MonticelloTonel-Core.package/TonelParser.class/instance/method.st
+++ b/MonticelloTonel-Core.package/TonelParser.class/instance/method.st
@@ -3,7 +3,7 @@ method
 	| type selector |
 
 	type := self untilIncluding: '>>'.
-	selector := self cleanSelector: (self untilExcluding: '[').
+	selector := self cleanSelector: (self selector).
 	type := type trimBoth substrings: ' '.
 	type size = 1 ifTrue: [ type := type copyWith: nil ].
 	^ {

--- a/MonticelloTonel-Core.package/TonelParser.class/instance/selector.st
+++ b/MonticelloTonel-Core.package/TonelParser.class/instance/selector.st
@@ -1,0 +1,9 @@
+parsing
+selector
+
+	^ String streamContents: [ :out |
+		  [ stream atEnd or: [ stream peek isSeparator not ] ] whileFalse: [ stream next ].
+		  [ stream atEnd or: [ stream peek isSeparator ] ] whileFalse: [
+			  out nextPut: stream next ].
+		  [ stream atEnd or: [ '[!' includes: stream peek ] ] whileFalse: [
+			  out nextPut: stream next ] ]

--- a/MonticelloTonel-Core.package/TonelSourceScanner.class/instance/scan.st
+++ b/MonticelloTonel-Core.package/TonelSourceScanner.class/instance/scan.st
@@ -1,6 +1,18 @@
 scanning
 scan
 	self prepareToScan.
+	stream peek = $! ifTrue: [
+		"Robust mode, source use a *chunk* format. existing ! are escaped (doubled)"
+		stream next.
+		^ (String streamContents: [ :str |
+			| ch |
+			[	ch := stream peek.
+				ch ~= $! or: [ 
+					stream next.
+					ch := stream peek.
+					ch = $! ] ]
+			whileTrue: [ str nextPut: stream next ] ] ) withInternalLineEndings ].
+
 	stream peek = $[ ifFalse: [ TonelParseError signal: 'Can''t parse method body' ].
 	[ stream atEnd or: [ isFinished ] ]
 	whileFalse: [ self scanNextChunk ].

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/writeMethodBody.on..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/writeMethodBody.on..st
@@ -1,0 +1,6 @@
+private - writing
+writeMethodBody: methodBody on: aStream
+
+	| nl |
+	nl := self newLine.
+	aStream << ' [' << methodBody << nl << ']' << nl

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/writeMethodBody.on..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/writeMethodBody.on..st
@@ -1,6 +1,19 @@
 private - writing
 writeMethodBody: methodBody on: aStream
 
-	| nl |
+	| nl reader |
 	nl := self newLine.
+	
+	"Check is the current body is robust. The most correct approach is to try to read it back"
+	reader := ('[' , methodBody , ']') readStream.
+	[ (TonelSourceScanner on: reader) scan ] on: TonelParseError do: [ reader := nil ].
+	(reader isNotNil and: [ reader atEnd ]) ifFalse: [
+		"If parse failed, then use an alternative robust *chunk* format instead.
+		Body is strictly delimited by `!` and existing `!` in the content are doubled"
+		aStream << ' !'.
+		methodBody do: [ :each |
+			each = $! ifTrue: [ aStream << $! ].
+			aStream << each ].
+		aStream << '!' << nl.
+		^ self ].
 	aStream << ' [' << methodBody << nl << ']' << nl

--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/writeMethodDefinition.parent.on..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/writeMethodDefinition.parent.on..st
@@ -10,5 +10,5 @@ writeMethodDefinition: aMethodDefinition parent: aClassDefinition on: aStream
 			aStream
 				<< nl
 				<< (self methodDefinitionOf: aMethodDefinition) << nl
-				<< fullClassName << ' >> ' << methodDeclaration
-				<< ' [' << methodBody << nl << ']' << nl ]
+				<< fullClassName << ' >> ' << methodDeclaration.
+			self writeMethodBody: methodBody on: aStream ]

--- a/MonticelloTonel-Tests.package/TonelParserTest.class/instance/testMethodRobustBody.st
+++ b/MonticelloTonel-Tests.package/TonelParserTest.class/instance/testMethodRobustBody.st
@@ -1,0 +1,18 @@
+tests
+testMethodRobustBody
+	self
+		assertParse: '!¿["''#(#{({!'
+		rule: #methodBody
+		equals: '¿["''#(#{({'.
+	self
+		assertParse: '!])}¿!'
+		rule: #methodBody
+		equals: '])}¿'.
+	self
+		assertParse: '!!!!'
+		rule: #methodBody
+		equals: '!'.
+	self
+		assertParse: '!!!a!!!!b!!!'
+		rule: #methodBody
+		equals: '!a!!b!'.

--- a/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteRobustMethodDefinitionOn.st
+++ b/MonticelloTonel-Tests.package/TonelWriterTest.class/instance/testWriteRobustMethodDefinitionOn.st
@@ -1,0 +1,63 @@
+tests
+testWriteRobustMethodDefinitionOn
+
+	| writer def stream |
+	writer := self actualClass new.
+
+	"To much closer"
+	stream := String new writeStream.
+	def := MCMethodDefinition
+		       className: #Object
+		       classIsMeta: false
+		       selector: #selector
+		       category: 'accessing'
+		       timeStamp: nil
+		       source: 'selector ^ ] 42'.
+	writer writeMethodDefinition: def on: stream.
+	self
+		assert: stream contents lines last
+		equals: 'Object >> selector ! ^ ] 42!'.
+	
+	"To much opener"
+	stream := String new writeStream.
+	def := MCMethodDefinition
+		       className: #Object
+		       classIsMeta: false
+		       selector: #selector
+		       category: 'accessing'
+		       timeStamp: nil
+		       source: 'selector ^ [ 42'.
+	writer writeMethodDefinition: def on: stream.
+	self
+		assert: stream contents lines last
+		equals: 'Object >> selector ! ^ [ 42!'.
+
+	"To much quotes"
+	stream := String new writeStream.
+	def := MCMethodDefinition
+		       className: #Object
+		       classIsMeta: false
+		       selector: #selector
+		       category: 'accessing'
+		       timeStamp: nil
+		       source: 'selector ^ " 42'.
+
+	writer writeMethodDefinition: def on: stream.
+	self
+		assert: stream contents lines last
+		equals: 'Object >> selector ! ^ " 42!'.
+		
+	"To much everything"
+	stream := String new writeStream.
+	def := MCMethodDefinition
+		       className: #Object
+		       classIsMeta: false
+		       selector: #selector
+		       category: 'accessing'
+		       timeStamp: nil
+		       source: 'selector ^ " '' #[ [ #( { ! !! 42 " '' ] ) }'.
+
+	writer writeMethodDefinition: def on: stream.
+	self
+		assert: stream contents lines last
+		equals: 'Object >> selector ! ^ " '' #[ [ #( { !! !!!! 42 " '' ] ) }!'.


### PR DESCRIPTION
The tonel format expects that the definition of a method is a sane superset of Pharo/Smalltalk.

The idea is that the resulting files looks like some *classic* source files from some *classic* programming languages that can easily be visualized, merged, hacked, etc. by humans. Instead of a random serialization format.

However, the current format cannot deal with method using some extended syntax that does not conform to the ad hoc rules of the tonel method content. Worse, tonel will blindly accept to save those methods not following those rules, thus creating files that won't be readable.
As a simple illustrative example, we can imagine weird fancy literals: for interpolation, for regex, for new separators that just will break the format. E.g `foo ^ '#[ $' ]'`  or `bar ^ ##/"hell/` or `foo ^ «french][style»` or whatever Pharo users want to experiment.
Also, it cannot deal with methods containing some syntax errors without corruption of the whole file, thus preventing the reparation of the offending methods.

Because of the current format with `[]` and a content that must follow some specific matching rules, there is no easy way to adapt it to be compatible with an extended, more robust format.
We want neither to change radically the format, nor losing the good human-related features.
Therefore, I propose a third approach: a specific *degraded* mode that is *robust* but *only* used if the tonel pure format is not usable.
For that, I reused a syntax I have seen in the CodeImporter with `!` as delimiter.

So, If the format `method [ methodBody ]` cannot be used because `methodBody` is not clean, the format `method !methodBody!` is used, where all `!` present in methodBody are escaped (by doubling them, classic Pharo/Smalltalk idiom).
Therefore, `methodBody` can contain any kind of garbage without breaking the whole file.

Note that there is no loss of functionality, the alternative being a corrupted file