### PR TITLE
Fix bug with missmatch in case of package

### DIFF
--- a/MonticelloTonel-Core.package/TonelReader.class/instance/ensurePackagesAndTagsOfDefinitions..st
+++ b/MonticelloTonel-Core.package/TonelReader.class/instance/ensurePackagesAndTagsOfDefinitions..st
@@ -9,11 +9,11 @@ ensurePackagesAndTagsOfDefinitions: aCollectionOfDefinition
 	aCollectionOfDefinition
 		select: [ :definition | definition isClassDefinition ]
 		thenDo: [ :classDefinition |
-			classDefinition packageName = packageName ifFalse: [
-				(classDefinition packageName beginsWith: packageName , '-')
+			(classDefinition packageName sameAs: packageName) ifFalse: [
+				(classDefinition packageName beginsWith: packageName , '-' caseSensitive: false)
 					ifTrue: [
 						classDefinition
-							tagName: (classDefinition packageName withoutPrefix: packageName , '-');
+							tagName: (classDefinition packageName allButFirst: packageName size + 1);
 							packageName: packageName ]
 					ifFalse: [
 						self error:

--- a/MonticelloTonel-Tests.package/TonelReaderTest.class/instance/testReadClassWithCategoryAsPackageAndMissmatchInCase.st
+++ b/MonticelloTonel-Tests.package/TonelReaderTest.class/instance/testReadClassWithCategoryAsPackageAndMissmatchInCase.st
@@ -1,0 +1,26 @@
+tests
+testReadClassWithCategoryAsPackageAndMissmatchInCase
+
+	| classDefinition |
+	classDefinition := self readDefinitionOfClass: 'MTMockSubclassOfA' fromPackage: 'MonticelloTonel-Tests-Mocks' whitContent: '"
+A comment
+"
+Class {
+	#name : #MTMockSubclassOfA,
+	#superclass : #MTMockClassA,
+	#instVars : [
+		''x''
+	],
+	#classVars : [
+		''Y''
+	],
+	#category : #''MonticelloTonel-tests-mocks''
+}'.
+
+	self assert: classDefinition className equals: #MTMockSubclassOfA.
+	self assert: classDefinition superclassName equals: #MTMockClassA.
+	self assertCollection: classDefinition instVarNames hasSameElements: #( 'x' ).
+	self assertCollection: classDefinition classVarNames hasSameElements: #( 'Y' ).
+	self assert: classDefinition packageName equals: #'MonticelloTonel-tests-mocks'.
+	self assert: classDefinition tagName isNil.
+	self assert: classDefinition comment equals: 'A comment'


### PR DESCRIPTION
It is possible that the folder whose name is equivalent to the name of a package and the category in a class metadata have different cases in Tonel. 

This manages this case and add a test that is failing without the fix