### PR TITLE
Simplify repository creation

### DIFF
--- a/MonticelloTonel-Core.package/TonelRepository.class/class/createRepositoryFromSpec..st
+++ b/MonticelloTonel-Core.package/TonelRepository.class/class/createRepositoryFromSpec..st
@@ -1,0 +1,6 @@
+metacello support
+createRepositoryFromSpec: aRepositorySpec
+
+	^ self new
+		  directory: (aRepositorySpec description copyFrom: (aRepositorySpec type , '://') size + 1 to: aRepositorySpec description size) asFileReference;
+		  yourself

--- a/MonticelloTonel-Core.package/TonelRepository.class/class/createRepositoryFromSpec.on..st
+++ b/MonticelloTonel-Core.package/TonelRepository.class/class/createRepositoryFromSpec.on..st
@@ -1,3 +1,0 @@
-metacello support
-createRepositoryFromSpec: aRepositorySpec on: aPlatform
-	^ aPlatform createTonelRepository: aRepositorySpec


### PR DESCRIPTION
This change has for goal to move the repository creation from MetacelloPlatform to TonelRepository to simplify the code