### PR TITLE
Fix #writeExtensionMethods:className: on TonelWriter to sort methods with the same selector consistently

### DIFF
--- a/MonticelloTonel-Core.package/TonelWriter.class/instance/writeExtensionMethods.className..st
+++ b/MonticelloTonel-Core.package/TonelWriter.class/instance/writeExtensionMethods.className..st
@@ -11,5 +11,5 @@ writeExtensionMethods: methods className: className
 			definition := Dictionary new.
 			self at: #name put: className in: definition.
 			s << 'Extension ' << (self toSTON: definition) << nl.
-			(methods sorted: [ :a :b | a selector < b selector ]) do: [ :each |
-				self writeMethodDefinition: each on: s ] ]
+			(methods sorted: [ :a :b | a selector < b selector or: [ a selector = b selector and: [ a classIsMeta ] ] ])
+				do: [ :each | self writeMethodDefinition: each on: s ] ]


### PR DESCRIPTION
This pull request fixes `#writeExtensionMethods:className:` on TonelWriter to sort methods with the same selector consistently (putting the metaclass’s method first). This avoids the confusing reordering of, for example, the `#taskbarIconName` methods in ‘Object.extension.st’ in ‘Morphic-Base’ like in Pharo commits [56e2288f4b](https://github.com/pharo-project/pharo/commit/56e2288f4b3229b7a59d7a0cdd8766d60c90d5c1), [cad205a6a3](https://github.com/pharo-project/pharo/commit/cad205a6a382144cbc2aec84b9fbe137178d4399), [206ca1db95](https://github.com/pharo-project/pharo/commit/206ca1db950da40999d942cd61bcc4e8f87f8d2d), [3b669bacaa](https://github.com/pharo-project/pharo/commit/3b669bacaa67e2d353a99517bf0f782de579413e) and [c403ecc570](https://github.com/pharo-project/pharo/commit/c403ecc5709099e79a10d4bca3d3c0139dd7c307). The snippet given in [Pharo pull request #14743](https://github.com/pharo-project/pharo/pull/14743) could be used to rewrite all ‘.extension.st’ files but that may cause merge conflicts in some open pull requests.