### PR TITLE
Adapt #asReposirotySpec: to the new version of Metacello

### DIFF
--- a/MonticelloTonel-Core.package/TonelRepository.class/instance/asRepositorySpec.st
+++ b/MonticelloTonel-Core.package/TonelRepository.class/instance/asRepositorySpec.st
@@ -1,5 +1,5 @@
 accessing
-asRepositorySpecFor: aMetacelloMCProject
+asRepositorySpec
 
 	^ (MetacelloRepositorySpec description: self description)
 		  type: 'tonel';


### PR DESCRIPTION
The method is getting renamed, so for now I keep both versions